### PR TITLE
churn use case training workflow - wml

### DIFF
--- a/mlmonitor/use_case_churn/factsheets.py
+++ b/mlmonitor/use_case_churn/factsheets.py
@@ -11,7 +11,7 @@ from ibm_aigov_facts_client import (
 )
 
 try:
-    from use_case_churn.utils import git_branch
+    from mlmonitor.use_case_churn.utils import git_branch
 except ImportError:
     from utils import git_branch
 


### PR DESCRIPTION
Fix incomplete import to be able to train use_case_churn model (xgboost)

```
from mlmonitor import WMLModelUseCase

wml_model_uc = WMLModelUseCase(source_dir='use_case_churn', catalog_id=catalog_id, model_entry_id=model_entry_id)

wml_model_uc.train()
```